### PR TITLE
fix typo in theme-ui-components.mdx

### DIFF
--- a/demo/src/pages/theme-ui-components.mdx
+++ b/demo/src/pages/theme-ui-components.mdx
@@ -4,7 +4,7 @@ navigationLabel: theme-ui/components
 
 # [theme-ui/components](#theme-ui-components)
 
-gatsby-theme-terminal also supports the full set of [theme-ui/componets](https://theme-ui.com/components) and below is how you use them.
+gatsby-theme-terminal also supports the full set of [theme-ui/components](https://theme-ui.com/components) and below is how you use them.
 
 If you'd like to see the default theme `.js` that file can be found in [here](https://github.com/PaulieScanlon/gatsby-theme-terminal/blob/master/%40pauliescanlon/gatsby-theme-terminal/src/gatsby-plugin-theme-ui/index.js)
 


### PR DESCRIPTION
Cool theme. Noticed a small typo when looking at the demo. No idea about the Divider change on line 729 (made change using Github editor).